### PR TITLE
Provide the Site context to Data repositories

### DIFF
--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -81,7 +81,10 @@ class CoreSite extends AbstractSite {
 		$className = "{$this->getSiteConfig()['NAMESPACE_APP']}Classes\\Data\\{$repositoryName}";
 		if (class_exists($className)) {
 			$repository = new $className();
-			$repository->setSite($this);
+			$setSiteMethod = 'setSite';
+			if (is_callable(array($repository,$setSiteMethod))) {
+				$repository->$setSiteMethod($this);
+			}
 			return $repository;
 		}
 		$this->getLogger()->error("Could not find Repository: ".$repositoryName);

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -80,7 +80,9 @@ class CoreSite extends AbstractSite {
 	public function getDataRepository($repositoryName) {
 		$className = "{$this->getSiteConfig()['NAMESPACE_APP']}Classes\\Data\\{$repositoryName}";
 		if (class_exists($className)) {
-			return new $className();
+			$repository = new $className();
+			$repository->setSite($this);
+			return $repository;
 		}
 		$this->getLogger()->error("Could not find Repository: ".$repositoryName);
 		return null;

--- a/Core/Classes/Data/AbstractDataBaseRepository.php
+++ b/Core/Classes/Data/AbstractDataBaseRepository.php
@@ -10,6 +10,8 @@ use Core\Interfaces as Interfaces;
 */
 
 abstract class AbstractDataBaseRepository extends DBObject implements Interfaces\DataBaseRepository {
+	/** @var Interfaces\Site $site This provides the Site context to all DatabaseRepositories extending this class */
+	protected $site;
 	/** @var string $primaryTable This is the name of the DB table managed by DatabaseRepositories extending this class */
 	protected $primaryTable;
 	/** @var string $primaryKey This is the name of the Primary Key for the $primaryTable managed by DatabaseRepositories extending this class */
@@ -126,5 +128,22 @@ abstract class AbstractDataBaseRepository extends DBObject implements Interfaces
 	*/
 	public function update($id,$data) {
 		return $this->buildUpdateStatement($id,$data);
+	}
+
+	/**
+	*	Get the Site context
+	*	@return Interfaces\Site $site The Site context
+	*/
+	protected function getSite() {
+		return $this->site;
+	}
+
+	/**
+	*	Set the Site context
+	*	@param Interfaces\Site $site The Site context
+	*	@return void
+	*/
+	public function setSite($site) {
+		$this->site = $site;
 	}
 }


### PR DESCRIPTION
With access to the Site context, Data repositories will be able to:
- Access config properties without resorting to the $GLOBALS array.
- Use Site's getDataRepository() to get and use other Data repositories