### PR TITLE
Issue 62

### DIFF
--- a/Core/Classes/AbstractSite.php
+++ b/Core/Classes/AbstractSite.php
@@ -125,4 +125,11 @@ abstract class AbstractSite extends CoreObject implements Interfaces\Site {
 	*	@param string The name of the desired Interfaces\DataRepository
 	*/
 	abstract public function getDataRepository($repositoryName);
+
+	/**
+	*	Provides a uniform approach to fetching Helper service classes
+	*	Should handle all instantiation and any desired caching of Helpers
+	*	@param string The name of the desired Helper
+	*/
+	abstract public function getHelper($helperName);
 }

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -174,11 +174,7 @@ class CoreSite extends AbstractSite {
 				//We found a Helper named $helperName, so let's instantiate, configure and cache it
 				if (class_exists($className)) {
 					$helper = new $className();
-					$setSiteMethod = 'setSite';
-					//provides the CoreSite instance to Helpers that have asked for it.
-					if (is_callable(array($helper,$setSiteMethod))) {
-						$helper->$setSiteMethod($this);
-					}
+					$helper->configure($this);
 					$this->addCachedHelper($helperName,$helper);
 					$this->getLogger()->debug("Providing FRESH Helper: ".$helperName);
 					break;

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -9,6 +9,8 @@ namespace Core\Classes;
 class CoreSite extends AbstractSite {
 	/** @var Core\Interfaces\DataRepository[] $cachedDataRepositories A store of DataRepositories to provide (singletons) to requestors */
 	protected $cachedDataRepositories = array();
+	/** @var object[] $cachedHelpers A store of Helpers to provide (singletons) to requestors */
+	protected $cachedHelpers = array();
 	/** @var string $redirectUrl A url to be redirected to */
 	private $redirectUrl = null;
 	/** @var string $dynamicRepositoryKey The key to the location in $siteConfig of an array of DynamicRepositoryConfiguration */
@@ -156,6 +158,47 @@ class CoreSite extends AbstractSite {
 	*/
 	protected function getCachedDataRepository($repositoryName) {
 		return array_key_exists($repositoryName, $this->cachedDataRepositories) ? $this->cachedDataRepositories[$repositoryName]:null;
+	}
+
+	/**
+	*	Fetch a Helper from the cache by its name
+	*	@param string $helperName The name of the desired Helper
+	*	@return object|null 
+	*/
+	public function getHelper($helperName) {
+		//first check if we've already instantiated this Helper
+		$helper = $this->getCachedHelper($helperName);
+		if (!$helper) {
+			foreach (array($this->getSiteConfig()['NAMESPACE_APP'],$this->getSiteConfig()['NAMESPACE_CORE']) as $classPath) {
+				$className = "{$classPath}Classes\\Helpers\\{$helperName}";
+				//We found a Helper named $helperName, so let's instantiate, configure and cache it
+				if (class_exists($className)) {
+					$helper = new $className();
+					$setSiteMethod = 'setSite';
+					//provides the CoreSite instance to Helpers that have asked for it.
+					if (is_callable(array($helper,$setSiteMethod))) {
+						$helper->$setSiteMethod($this);
+					}
+					$this->addCachedHelper($helperName,$helper);
+					$this->getLogger()->debug("Providing FRESH Helper: ".$helperName);
+					break;
+				}
+			}
+			if (!$helper) {
+				$this->getLogger()->error("Could not find Helper: ".$helperName);
+			}
+		} else {
+			$this->getLogger()->debug("Providing CACHED Helper: ".$helperName);
+		}
+		return $helper;
+	}
+
+	protected function addCachedHelper($helperName,$helperInstance) {
+		$this->cachedHelpers[$helperName] = $helperInstance;
+	}
+
+	protected function getCachedHelper($helperName) {
+		return array_key_exists($helperName, $this->cachedHelpers) ? $this->cachedHelpers[$helperName]:null;
 	}
 
 	public function setRedirectUrl($redirectUrl) {

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -123,11 +123,7 @@ class CoreSite extends AbstractSite {
 				//We found a DataRepository named $repositoryName, so let's instantiate, configure and cache it
 				if (class_exists($className)) {
 					$repository = new $className();
-					$setSiteMethod = 'setSite';
-					//provides the CoreSite instance to DataRepositories that have asked for it.
-					if (is_callable(array($repository,$setSiteMethod))) {
-						$repository->$setSiteMethod($this);
-					}
+					$repository->configure($this);
 					$this->addCachedDataRepository($repositoryName,$repository);
 				}
 			}

--- a/Core/Classes/Data/AbstractDataBaseRepository.php
+++ b/Core/Classes/Data/AbstractDataBaseRepository.php
@@ -9,7 +9,7 @@ use Core\Interfaces as Interfaces;
 *	@author Jason Savell <jsavell@library.tamu.edu>
 */
 
-abstract class AbstractDataBaseRepository extends DBObject implements Interfaces\DataRepository {
+abstract class AbstractDataBaseRepository extends DBObject implements Interfaces\DataRepository, Interfaces\Configurable {
 	/** @var Interfaces\Site $site This provides the Site context to all DatabaseRepositories extending this class */
 	protected $site;
 	/** @var string $primaryTable This is the name of the DB table managed by DatabaseRepositories extending this class */
@@ -149,5 +149,9 @@ abstract class AbstractDataBaseRepository extends DBObject implements Interfaces
 	*/
 	public function setSite($site) {
 		$this->site = $site;
+	}
+
+	public function configure(Interfaces\Site $site) {
+		$this->setSite($site);
 	}
 }

--- a/Core/Classes/Data/SimpleFile.php
+++ b/Core/Classes/Data/SimpleFile.php
@@ -1,0 +1,61 @@
+<?php
+namespace Core\Classes\Data;
+use Core\Interfaces as Interfaces;
+/** 
+ * Represents a file entry
+ *
+ * @author Jason Savell <jsavell@library.tamu.edu>
+ */
+class SimpleFile implements Interfaces\File {
+	private $fileName;
+	private $filePath;
+	private $fileType;
+	private $gloss;
+
+	public function __construct($fileName,$filePath,$fileType=null,$gloss=null) {
+		$this->setFileName($fileName);
+		$this->setFilePath($filePath);
+		$this->setFileType($fileType);
+		$this->setGloss($gloss);
+	}
+
+	protected function setFileName($fileName) {
+		$this->fileName = $fileName;
+	}
+
+	protected function setFilePath($filePath) {
+		$this->filePath = $filePath;
+	}
+
+	protected function setFileType($fileType) {
+		$this->fileType = $fileType;
+	}
+
+	protected function setGloss($gloss) {
+		$this->gloss = $gloss;
+	}
+
+	public function getFileName() {
+		return $this->fileName;
+	}
+
+	public function getFilePath() {
+		return $this->filePath;
+	}
+
+	public function getFileType() {
+		return $this->fileType;
+	}
+
+	public function getGloss() {
+		return $this->gloss;
+	}
+
+	public function getFullPath() {
+		$fullPath = $this->getFilePath();
+		if ($fullPath) {
+			$fullPath .= '/';
+		}
+		return $fullPath.$this->getFileName();
+	}
+}

--- a/Core/Classes/Data/SimpleFile.php
+++ b/Core/Classes/Data/SimpleFile.php
@@ -56,6 +56,6 @@ class SimpleFile implements Interfaces\File {
 		if ($fullPath) {
 			$fullPath .= '/';
 		}
-		return $fullPath.$this->getFileName();
+		return $fullPath.$this->getGloss();
 	}
 }

--- a/Core/Classes/Helpers/AbstractHelper.php
+++ b/Core/Classes/Helpers/AbstractHelper.php
@@ -1,8 +1,9 @@
 <?php
 namespace Core\Classes\Helpers;
 use Core\Classes as CoreClasses;
+use Core\Interfaces as CoreInterfaces;
 
-abstract class AbstractHelper extends CoreClasses\CoreObject {
+abstract class AbstractHelper extends CoreClasses\CoreObject implements CoreInterfaces\Configurable {
 	private $site;
 
 	public function getSite() {
@@ -11,5 +12,12 @@ abstract class AbstractHelper extends CoreClasses\CoreObject {
 
 	public function setSite($site) {
 		$this->site = $site;
+	}
+
+	/**
+	*	Override to handle any Helper specific configurations.
+	*/
+	public function configure(CoreInterfaces\Site $site) {
+		$this->setSite($site);
 	}
 }

--- a/Core/Classes/Helpers/AbstractHelper.php
+++ b/Core/Classes/Helpers/AbstractHelper.php
@@ -1,0 +1,15 @@
+<?php
+namespace Core\Classes\Helpers;
+use Core\Classes as CoreClasses;
+
+abstract class AbstractHelper extends CoreClasses\CoreObject {
+	private $site;
+
+	public function getSite() {
+		return $this->site;
+	}
+
+	public function setSite($site) {
+		$this->site = $site;
+	}
+}

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -1,0 +1,98 @@
+<?php
+namespace Core\Classes\Helpers;
+use Core\Interfaces as Interfaces;
+use Core\Classes\Data as CoreData;
+
+class FileManager extends AbstractHelper {
+	public function setSite($site) {
+		parent::setSite($site);
+		if (!$this->getSite()->getSiteConfig()['UPLOAD_PATH']) {
+			throw new \RuntimeException("The upload path has not been configured!");
+		}
+	}
+
+	public function getBaseFilePath() {
+		return $this->getSite()->getSiteConfig()['UPLOAD_PATH'];
+	}
+
+	public function processBase64File($encodedFile,$fileName=null,$fileDirectory=null) {
+		$temp = explode(",",$encodedFile);
+		$fileTypeTemp = explode(':',$temp[0]);
+		$fileType = explode(';',$fileTypeTemp[1])[0];
+		$fileExtension = explode('/',$fileType)[1];
+
+		$encodedFile = $temp[1];
+
+		$uploadedFile = base64_decode($encodedFile);
+		$uploadDir = $this->getBaseFilePath();
+		if ($fileDirectory) {
+			$uploadDir .= $fileDirectory.'/';
+		}
+
+		$this->createDirectory($uploadDir);
+
+		if (!$fileName) {
+			$fileName = sha1($uploadedFile.' '.time());
+		}
+
+		$file = fopen($uploadDir.$fileName,'w');
+		if (!fwrite($file,$uploadedFile)) {
+			throw new \RuntimeException("Error writing file: ".$uploadDir.$fileName);
+		}
+		fclose($file);
+		return $fileName;
+	}
+
+	public function getDownloadableFileByFileName($fileName) {
+		return $this->getDownloadableFile(new CoreData\SimpleFile($fileName,null,null,$fileName));
+	}
+
+	public function getDownloadableFile(Interfaces\File $file) {
+		$fileLocation = $this->getBaseFilePath().$file->getFullPath();
+		header("Content-Type: image/png");
+		header("Content-Length: ".filesize($fileLocation));
+		header("Content-Disposition: attachment; filename=".($file->getGloss() ? $file->getGloss():$file->getFileName()));
+		readfile($fileLocation);
+		exit;
+	}
+
+	public function removeFile(Interfaces\File $file) {
+		if (!unlink($this->getBaseFilePath().$file->getFullPath())) {
+			throw new \RuntimeException("Error removing file: ".$this->getBaseFilePath().$file->getFullPath());
+		}
+		return true;
+	}
+
+	protected function createDirectory($directory) {
+		if (!file_exists($directory)) {
+		    if (!mkdir($directory, 0777, true)) {
+				throw new \RuntimeException("Error creating directory: {$directory}");
+			}
+		}
+	}
+
+	public function getDirectoryContents($directoryPath=null,$filesOnly=false) {
+		$pathNames = scandir($this->getBaseFilePath().$directoryPath);
+		if (!$pathNames) {
+			throw new \RuntimeException("Could not read directory: {$this->getBaseFilePath()}{$directoryPath}");
+		}
+		if ($filesOnly) {
+			$pathNames = array_filter($pathNames,function($value) { return !is_dir($value);});
+		}
+		$contents = array();
+		foreach ($pathNames as $path) {
+			$contents[] = pathinfo($path);
+		}
+		return $contents;
+	}
+
+	public function getDirectoryFiles($directoryPath=null) {
+		$contents = $this->getDirectoryContents($directoryPath,true);
+		$files = array();
+		foreach ($contents as $fileInfo) {
+			$files[] = new CoreData\SimpleFile($fileInfo['filename'],$directoryPath,$fileInfo['extension'],$fileInfo['basename']);
+		}
+		return $files;
+	}
+}
+?>

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -49,6 +49,7 @@ class FileManager extends AbstractHelper {
 
 	public function getDownloadableFile(Interfaces\File $file) {
 		$fileLocation = $this->getBaseFilePath().$file->getFullPath();
+		$this->checkFile($fileLocation);
 		header("Content-Type: ".mime_content_type($fileLocation));
 		header("Content-Length: ".filesize($fileLocation));
 		header("Content-Disposition: attachment; filename=".($file->getGloss() ? $file->getGloss():$file->getFileName()));
@@ -101,11 +102,15 @@ class FileManager extends AbstractHelper {
 
 	public function getFileFromFileName($fileName) {
 		$filePath = $this->getBaseFilePath().$fileName;
+		$this->checkFile($filePath);
+		$fileInfo = pathinfo($this->getBaseFilePath().$fileName);
+		return new CoreData\SimpleFile($fileInfo['filename'],null,$fileInfo['extension'],$fileInfo['basename']);
+	}
+
+	private function checkFile($filePath) {
 		if (!is_file($filePath)) {
 			throw new \RuntimeException("Could not find file: {$filePath}");
 		}
-		$fileInfo = pathinfo($this->getBaseFilePath().$fileName);
-		return new CoreData\SimpleFile($fileInfo['filename'],null,$fileInfo['extension'],$fileInfo['basename']);
 	}
 }
 ?>

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -44,16 +44,20 @@ class FileManager extends AbstractHelper {
 	}
 
 	public function getDownloadableFileByFileName($fileName) {
-		return $this->getDownloadableFile(new CoreData\SimpleFile($fileName,null,null,$fileName));
+		return $this->getDownloadableFile($this->getFileFromFileName($fileName));
 	}
 
 	public function getDownloadableFile(Interfaces\File $file) {
 		$fileLocation = $this->getBaseFilePath().$file->getFullPath();
-		header("Content-Type: image/png");
+		header("Content-Type: ".mime_content_type($fileLocation));
 		header("Content-Length: ".filesize($fileLocation));
 		header("Content-Disposition: attachment; filename=".($file->getGloss() ? $file->getGloss():$file->getFileName()));
 		readfile($fileLocation);
 		exit;
+	}
+
+	public function removeFileByFileName($fileName) {
+		return $this->removeFile($this->getFileFromFileName($fileName));
 	}
 
 	public function removeFile(Interfaces\File $file) {
@@ -90,9 +94,18 @@ class FileManager extends AbstractHelper {
 		$contents = $this->getDirectoryContents($directoryPath,true);
 		$files = array();
 		foreach ($contents as $fileInfo) {
-			$files[] = new CoreData\SimpleFile($fileInfo['filename'],$directoryPath,$fileInfo['extension'],$fileInfo['basename']);
+			$files[] = $this->getFileFromFileName($fileInfo['basename']);
 		}
 		return $files;
+	}
+
+	public function getFileFromFileName($fileName) {
+		$filePath = $this->getBaseFilePath().$fileName;
+		if (!is_file($filePath)) {
+			throw new \RuntimeException("Could not find file: {$filePath}");
+		}
+		$fileInfo = pathinfo($this->getBaseFilePath().$fileName);
+		return new CoreData\SimpleFile($fileInfo['filename'],null,$fileInfo['extension'],$fileInfo['basename']);
 	}
 }
 ?>

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -35,7 +35,7 @@ class FileManager extends AbstractHelper {
 			$fileName = sha1($uploadedFile.' '.time());
 		}
 
-		if ($file = fopen($uploadDir.$fileName,'w')) {
+		if (!($file = fopen($uploadDir.$fileName,'w'))) {
 			throw new \RuntimeException("Error opening file: ".$uploadDir.$fileName);
 		}
 		if (!fwrite($file,$uploadedFile)) {

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -4,8 +4,8 @@ use Core\Interfaces as Interfaces;
 use Core\Classes\Data as CoreData;
 
 class FileManager extends AbstractHelper {
-	public function setSite($site) {
-		parent::setSite($site);
+	public function configure(Interfaces\Site $site) {
+		parent::configure($site);
 		if (!$this->getSite()->getSiteConfig()['UPLOAD_PATH']) {
 			throw new \RuntimeException("The upload path has not been configured!");
 		}

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -77,12 +77,14 @@ class FileManager extends AbstractHelper {
 	}
 
 	public function getDirectoryContents($directoryPath=null,$filesOnly=false) {
-		$pathNames = scandir($this->getBaseFilePath().$directoryPath);
+		$scanDirectory = $this->getBaseFilePath().$directoryPath;
+		$pathNames = scandir($scanDirectory);
 		if (!$pathNames) {
-			throw new \RuntimeException("Could not read directory: {$this->getBaseFilePath()}{$directoryPath}");
+			throw new \RuntimeException("Could not read directory: {$scanDirectory}");
 		}
+
 		if ($filesOnly) {
-			$pathNames = array_filter($pathNames,function($value) { return !is_dir($value);});
+			$pathNames = array_filter($pathNames,function($value) use ($scanDirectory) { return !is_dir($scanDirectory.$value);});
 		}
 		$contents = array();
 		foreach ($pathNames as $path) {

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -35,7 +35,9 @@ class FileManager extends AbstractHelper {
 			$fileName = sha1($uploadedFile.' '.time());
 		}
 
-		$file = fopen($uploadDir.$fileName,'w');
+		if ($file = fopen($uploadDir.$fileName,'w')) {
+			throw new \RuntimeException("Error opening file: ".$uploadDir.$fileName);
+		}
 		if (!fwrite($file,$uploadedFile)) {
 			throw new \RuntimeException("Error writing file: ".$uploadDir.$fileName);
 		}

--- a/Core/Interfaces/Configurable.php
+++ b/Core/Interfaces/Configurable.php
@@ -1,0 +1,15 @@
+<?php
+namespace Core\Interfaces;
+/** 
+*	An interface defining a Configurable class
+*
+*	@author Jason Savell <jsavell@library.tamu.edu>
+*/
+
+interface Configurable {
+	/**
+	*	Allows instantiators of a Configurable class to trigger instance configuration *after* the __constructor() is callled
+	*/
+	public function configure(Site $site);
+}
+?>

--- a/Core/Interfaces/File.php
+++ b/Core/Interfaces/File.php
@@ -1,0 +1,9 @@
+<?php
+namespace Core\Interfaces;
+
+interface File {
+	public function getFileName();
+	public function getFilePath();
+	public function getFileType();
+	public function getGloss();
+}


### PR DESCRIPTION
Resolves #62 

- Introduces the concept of a Helper service. Similar to `getDataRepository()`, AbstractSite defines and CoreSite implements a `getHelper()` method to allow components like Controllers, Repositories, and othe Helpers to request an instance of a Helper to manage common tasks.

- Pipit Core's first implementation of a Helper is the FileManager for managing of file uploads and manipulation on the file system.

- Apps can define their own Helpers by placing classes that extend `Core\Classes\Helpers\AbstractHelper` in `Apps\Classes\Helpers`

