### PR TITLE
Merge File Manager feature

### DIFF
--- a/Core/Classes/AbstractSite.php
+++ b/Core/Classes/AbstractSite.php
@@ -125,4 +125,11 @@ abstract class AbstractSite extends CoreObject implements Interfaces\Site {
 	*	@param string The name of the desired Interfaces\DataRepository
 	*/
 	abstract public function getDataRepository($repositoryName);
+
+	/**
+	*	Provides a uniform approach to fetching Helper service classes
+	*	Should handle all instantiation and any desired caching of Helpers
+	*	@param string The name of the desired Helper
+	*/
+	abstract public function getHelper($helperName);
 }

--- a/Core/Classes/Data/AbstractDataBaseRepository.php
+++ b/Core/Classes/Data/AbstractDataBaseRepository.php
@@ -9,7 +9,7 @@ use Core\Interfaces as Interfaces;
 *	@author Jason Savell <jsavell@library.tamu.edu>
 */
 
-abstract class AbstractDataBaseRepository extends DBObject implements Interfaces\DataRepository {
+abstract class AbstractDataBaseRepository extends DBObject implements Interfaces\DataRepository, Interfaces\Configurable {
 	/** @var Interfaces\Site $site This provides the Site context to all DatabaseRepositories extending this class */
 	protected $site;
 	/** @var string $primaryTable This is the name of the DB table managed by DatabaseRepositories extending this class */
@@ -149,5 +149,9 @@ abstract class AbstractDataBaseRepository extends DBObject implements Interfaces
 	*/
 	public function setSite($site) {
 		$this->site = $site;
+	}
+
+	public function configure(Interfaces\Site $site) {
+		$this->setSite($site);
 	}
 }

--- a/Core/Classes/Data/SimpleFile.php
+++ b/Core/Classes/Data/SimpleFile.php
@@ -1,0 +1,61 @@
+<?php
+namespace Core\Classes\Data;
+use Core\Interfaces as Interfaces;
+/** 
+ * Represents a file entry
+ *
+ * @author Jason Savell <jsavell@library.tamu.edu>
+ */
+class SimpleFile implements Interfaces\File {
+	private $fileName;
+	private $filePath;
+	private $fileType;
+	private $gloss;
+
+	public function __construct($fileName,$filePath,$fileType=null,$gloss=null) {
+		$this->setFileName($fileName);
+		$this->setFilePath($filePath);
+		$this->setFileType($fileType);
+		$this->setGloss($gloss);
+	}
+
+	protected function setFileName($fileName) {
+		$this->fileName = $fileName;
+	}
+
+	protected function setFilePath($filePath) {
+		$this->filePath = $filePath;
+	}
+
+	protected function setFileType($fileType) {
+		$this->fileType = $fileType;
+	}
+
+	protected function setGloss($gloss) {
+		$this->gloss = $gloss;
+	}
+
+	public function getFileName() {
+		return $this->fileName;
+	}
+
+	public function getFilePath() {
+		return $this->filePath;
+	}
+
+	public function getFileType() {
+		return $this->fileType;
+	}
+
+	public function getGloss() {
+		return $this->gloss;
+	}
+
+	public function getFullPath() {
+		$fullPath = $this->getFilePath();
+		if ($fullPath) {
+			$fullPath .= '/';
+		}
+		return $fullPath.$this->getGloss();
+	}
+}

--- a/Core/Classes/Helpers/AbstractHelper.php
+++ b/Core/Classes/Helpers/AbstractHelper.php
@@ -1,0 +1,23 @@
+<?php
+namespace Core\Classes\Helpers;
+use Core\Classes as CoreClasses;
+use Core\Interfaces as CoreInterfaces;
+
+abstract class AbstractHelper extends CoreClasses\CoreObject implements CoreInterfaces\Configurable {
+	private $site;
+
+	public function getSite() {
+		return $this->site;
+	}
+
+	public function setSite($site) {
+		$this->site = $site;
+	}
+
+	/**
+	*	Override to handle any Helper specific configurations.
+	*/
+	public function configure(CoreInterfaces\Site $site) {
+		$this->setSite($site);
+	}
+}

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -1,0 +1,120 @@
+<?php
+namespace Core\Classes\Helpers;
+use Core\Interfaces as Interfaces;
+use Core\Classes\Data as CoreData;
+
+class FileManager extends AbstractHelper {
+	public function configure(Interfaces\Site $site) {
+		parent::configure($site);
+		if (!$this->getSite()->getSiteConfig()['UPLOAD_PATH']) {
+			throw new \RuntimeException("The upload path has not been configured!");
+		}
+	}
+
+	public function getBaseFilePath() {
+		return $this->getSite()->getSiteConfig()['UPLOAD_PATH'];
+	}
+
+	public function processBase64File($encodedFile,$fileName=null,$fileDirectory=null) {
+		$temp = explode(",",$encodedFile);
+		$fileTypeTemp = explode(':',$temp[0]);
+		$fileType = explode(';',$fileTypeTemp[1])[0];
+		$fileExtension = explode('/',$fileType)[1];
+
+		$encodedFile = $temp[1];
+
+		$uploadedFile = base64_decode($encodedFile);
+		$uploadDir = $this->getBaseFilePath();
+		if ($fileDirectory) {
+			$uploadDir .= $fileDirectory.'/';
+		}
+
+		$this->createDirectory($uploadDir);
+
+		if (!$fileName) {
+			$fileName = sha1($uploadedFile.' '.time());
+		}
+
+		if (!($file = fopen($uploadDir.$fileName,'w'))) {
+			throw new \RuntimeException("Error opening file: ".$uploadDir.$fileName);
+		}
+		if (!fwrite($file,$uploadedFile)) {
+			throw new \RuntimeException("Error writing file: ".$uploadDir.$fileName);
+		}
+		fclose($file);
+		return $fileName;
+	}
+
+	public function getDownloadableFileByFileName($fileName) {
+		return $this->getDownloadableFile($this->getFileFromFileName($fileName));
+	}
+
+	public function getDownloadableFile(Interfaces\File $file) {
+		$fileLocation = $this->getBaseFilePath().$file->getFullPath();
+		$this->checkFile($fileLocation);
+		header("Content-Type: ".mime_content_type($fileLocation));
+		header("Content-Length: ".filesize($fileLocation));
+		header("Content-Disposition: attachment; filename=".($file->getGloss() ? $file->getGloss():$file->getFileName()));
+		readfile($fileLocation);
+		exit;
+	}
+
+	public function removeFileByFileName($fileName) {
+		return $this->removeFile($this->getFileFromFileName($fileName));
+	}
+
+	public function removeFile(Interfaces\File $file) {
+		if (!unlink($this->getBaseFilePath().$file->getFullPath())) {
+			throw new \RuntimeException("Error removing file: ".$this->getBaseFilePath().$file->getFullPath());
+		}
+		return true;
+	}
+
+	protected function createDirectory($directory) {
+		if (!file_exists($directory)) {
+		    if (!mkdir($directory, 0777, true)) {
+				throw new \RuntimeException("Error creating directory: {$directory}");
+			}
+		}
+	}
+
+	public function getDirectoryContents($directoryPath=null,$filesOnly=false) {
+		$scanDirectory = $this->getBaseFilePath().$directoryPath;
+		$pathNames = scandir($scanDirectory);
+		if (!$pathNames) {
+			throw new \RuntimeException("Could not read directory: {$scanDirectory}");
+		}
+
+		if ($filesOnly) {
+			$pathNames = array_filter($pathNames,function($value) use ($scanDirectory) { return !is_dir($scanDirectory.$value);});
+		}
+		$contents = array();
+		foreach ($pathNames as $path) {
+			$contents[] = pathinfo($path);
+		}
+		return $contents;
+	}
+
+	public function getDirectoryFiles($directoryPath=null) {
+		$contents = $this->getDirectoryContents($directoryPath,true);
+		$files = array();
+		foreach ($contents as $fileInfo) {
+			$files[] = $this->getFileFromFileName($fileInfo['basename']);
+		}
+		return $files;
+	}
+
+	public function getFileFromFileName($fileName) {
+		$filePath = $this->getBaseFilePath().$fileName;
+		$this->checkFile($filePath);
+		$fileInfo = pathinfo($this->getBaseFilePath().$fileName);
+		return new CoreData\SimpleFile($fileInfo['filename'],null,$fileInfo['extension'],$fileInfo['basename']);
+	}
+
+	private function checkFile($filePath) {
+		if (!is_file($filePath)) {
+			throw new \RuntimeException("Could not find file: {$filePath}");
+		}
+	}
+}
+?>

--- a/Core/Interfaces/Configurable.php
+++ b/Core/Interfaces/Configurable.php
@@ -1,0 +1,15 @@
+<?php
+namespace Core\Interfaces;
+/** 
+*	An interface defining a Configurable class
+*
+*	@author Jason Savell <jsavell@library.tamu.edu>
+*/
+
+interface Configurable {
+	/**
+	*	Allows instantiators of a Configurable class to trigger instance configuration *after* the __constructor() is callled
+	*/
+	public function configure(Site $site);
+}
+?>

--- a/Core/Interfaces/File.php
+++ b/Core/Interfaces/File.php
@@ -1,0 +1,9 @@
+<?php
+namespace Core\Interfaces;
+
+interface File {
+	public function getFileName();
+	public function getFilePath();
+	public function getFileType();
+	public function getGloss();
+}


### PR DESCRIPTION
Resolves #62 

- Introduces the concept of a Helper service. Similar to `getDataRepository()`, AbstractSite defines and CoreSite implements a `getHelper()` method to allow components like Controllers, Repositories, and othe Helpers to request an instance of a Helper to manage common tasks.

- Pipit Core's first implementation of a Helper is the FileManager for managing of file uploads and manipulation on the file system.

- Apps can define their own Helpers by placing classes that extend `Core\Classes\Helpers\AbstractHelper` in `Apps\Classes\Helpers`

