### PR TITLE
Remove closing PHP tags

### DIFF
--- a/Core/Classes/AbstractSitePage.php
+++ b/Core/Classes/AbstractSitePage.php
@@ -100,4 +100,3 @@ abstract class AbstractSitePage implements Interfaces\SitePage {
 	abstract public function setSearchableFields($searchableFields);
 	abstract public function getSearchableFields();
 }
-?>

--- a/Core/Classes/AbstractSitePage.php
+++ b/Core/Classes/AbstractSitePage.php
@@ -100,3 +100,4 @@ abstract class AbstractSitePage implements Interfaces\SitePage {
 	abstract public function setSearchableFields($searchableFields);
 	abstract public function getSearchableFields();
 }
+

--- a/Core/Classes/Configuration/DynamicDatabaseRepositoryConfiguration.php
+++ b/Core/Classes/Configuration/DynamicDatabaseRepositoryConfiguration.php
@@ -39,4 +39,3 @@ class DynamicDatabaseRepositoryConfiguration extends AbstractConfiguration {
 		return $this->searchableColumns;
 	}
 }
-?>

--- a/Core/Classes/Configuration/DynamicDatabaseRepositoryConfiguration.php
+++ b/Core/Classes/Configuration/DynamicDatabaseRepositoryConfiguration.php
@@ -39,3 +39,4 @@ class DynamicDatabaseRepositoryConfiguration extends AbstractConfiguration {
 		return $this->searchableColumns;
 	}
 }
+

--- a/Core/Classes/CoreLogger.php
+++ b/Core/Classes/CoreLogger.php
@@ -118,4 +118,3 @@ class CoreLogger implements Interfaces\Logger {
 		return implode(', ',array("line"=>"L{$rawCaller['line']}","file"=>"File: {$rawCaller['file']}","function"=>"Function: {$rawCaller['function']}"));
 	}
 }
-?>

--- a/Core/Classes/CoreLogger.php
+++ b/Core/Classes/CoreLogger.php
@@ -118,3 +118,4 @@ class CoreLogger implements Interfaces\Logger {
 		return implode(', ',array("line"=>"L{$rawCaller['line']}","file"=>"File: {$rawCaller['file']}","function"=>"Function: {$rawCaller['function']}"));
 	}
 }
+

--- a/Core/Classes/CoreObject.php
+++ b/Core/Classes/CoreObject.php
@@ -31,4 +31,3 @@ class CoreObject {
 		return $this->logger;
 	}
 }
-?>

--- a/Core/Classes/CoreObject.php
+++ b/Core/Classes/CoreObject.php
@@ -31,3 +31,4 @@ class CoreObject {
 		return $this->logger;
 	}
 }
+

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -216,4 +216,3 @@ class CoreSite extends AbstractSite {
 		$this->dynamicRepositoryKey = $dynamicRepositoryKey;
 	}
 }
-?>

--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -216,3 +216,4 @@ class CoreSite extends AbstractSite {
 		$this->dynamicRepositoryKey = $dynamicRepositoryKey;
 	}
 }
+

--- a/Core/Classes/CoreSitePage.php
+++ b/Core/Classes/CoreSitePage.php
@@ -59,3 +59,4 @@ class CoreSitePage extends AbstractSitePage {
 		return $this->searchableFields;
 	}
 }
+

--- a/Core/Classes/CoreSitePage.php
+++ b/Core/Classes/CoreSitePage.php
@@ -59,4 +59,3 @@ class CoreSitePage extends AbstractSitePage {
 		return $this->searchableFields;
 	}
 }
-?>

--- a/Core/Classes/CoreSystemMessage.php
+++ b/Core/Classes/CoreSystemMessage.php
@@ -40,4 +40,3 @@ class CoreSystemMessage implements Interfaces\SystemMessage {
 		return $this->message;
 	}
 }
-?>

--- a/Core/Classes/CoreSystemMessage.php
+++ b/Core/Classes/CoreSystemMessage.php
@@ -40,3 +40,4 @@ class CoreSystemMessage implements Interfaces\SystemMessage {
 		return $this->message;
 	}
 }
+

--- a/Core/Classes/Data/DBObject.php
+++ b/Core/Classes/Data/DBObject.php
@@ -280,4 +280,3 @@ class DBObject extends CoreClasses\CoreObject {
 		}
 	}
 }
-?>

--- a/Core/Classes/Data/DBObject.php
+++ b/Core/Classes/Data/DBObject.php
@@ -280,3 +280,4 @@ class DBObject extends CoreClasses\CoreObject {
 		}
 	}
 }
+

--- a/Core/Classes/Data/UserCAS.php
+++ b/Core/Classes/Data/UserCAS.php
@@ -83,4 +83,3 @@ class UserCAS extends UserDB {
 		header("Location: {$this->casPaths['urls']['logout']}");
 	}
 }
-?>

--- a/Core/Classes/Data/UserCAS.php
+++ b/Core/Classes/Data/UserCAS.php
@@ -83,3 +83,4 @@ class UserCAS extends UserDB {
 		header("Location: {$this->casPaths['urls']['logout']}");
 	}
 }
+

--- a/Core/Classes/Data/UserDB.php
+++ b/Core/Classes/Data/UserDB.php
@@ -152,4 +152,3 @@ class UserDB extends DBObject implements Interfaces\User {
 		return false;
 	}
 }
-?>

--- a/Core/Classes/Data/UserDB.php
+++ b/Core/Classes/Data/UserDB.php
@@ -152,3 +152,4 @@ class UserDB extends DBObject implements Interfaces\User {
 		return false;
 	}
 }
+

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -117,3 +117,4 @@ class FileManager extends AbstractHelper {
 		}
 	}
 }
+

--- a/Core/Classes/Helpers/FileManager.php
+++ b/Core/Classes/Helpers/FileManager.php
@@ -117,4 +117,3 @@ class FileManager extends AbstractHelper {
 		}
 	}
 }
-?>

--- a/Core/Classes/Loaders/CoreLoader.php
+++ b/Core/Classes/Loaders/CoreLoader.php
@@ -189,4 +189,3 @@ class CoreLoader implements CoreInterfaces\Loader {
 		$this->getSite()->getViewRenderer()->renderView();
 	}
 }
-?>

--- a/Core/Classes/Loaders/CoreLoader.php
+++ b/Core/Classes/Loaders/CoreLoader.php
@@ -189,3 +189,4 @@ class CoreLoader implements CoreInterfaces\Loader {
 		$this->getSite()->getViewRenderer()->renderView();
 	}
 }
+

--- a/Core/Classes/ViewRenderers/CSVViewRenderer.php
+++ b/Core/Classes/ViewRenderers/CSVViewRenderer.php
@@ -44,3 +44,4 @@ class CSVViewRenderer extends JSONViewRenderer {
 		$this->csvFileName = $csvFileName;
 	}
 }
+

--- a/Core/Classes/ViewRenderers/CSVViewRenderer.php
+++ b/Core/Classes/ViewRenderers/CSVViewRenderer.php
@@ -44,4 +44,3 @@ class CSVViewRenderer extends JSONViewRenderer {
 		$this->csvFileName = $csvFileName;
 	}
 }
-?>

--- a/Core/Classes/ViewRenderers/HTMLViewRenderer.php
+++ b/Core/Classes/ViewRenderers/HTMLViewRenderer.php
@@ -186,3 +186,4 @@ class HTMLViewRenderer extends CoreClasses\CoreObject implements Interfaces\View
 		$this->registerAppContextProperty("page",$page);
 	}
 }
+

--- a/Core/Classes/ViewRenderers/HTMLViewRenderer.php
+++ b/Core/Classes/ViewRenderers/HTMLViewRenderer.php
@@ -186,4 +186,3 @@ class HTMLViewRenderer extends CoreClasses\CoreObject implements Interfaces\View
 		$this->registerAppContextProperty("page",$page);
 	}
 }
-?>

--- a/Core/Classes/ViewRenderers/JSONViewRenderer.php
+++ b/Core/Classes/ViewRenderers/JSONViewRenderer.php
@@ -80,4 +80,3 @@ class JSONViewRenderer implements Interfaces\ViewRenderer {
 	public function setPage($page) {
 	}
 }
-?>

--- a/Core/Classes/ViewRenderers/JSONViewRenderer.php
+++ b/Core/Classes/ViewRenderers/JSONViewRenderer.php
@@ -80,3 +80,4 @@ class JSONViewRenderer implements Interfaces\ViewRenderer {
 	public function setPage($page) {
 	}
 }
+

--- a/Core/Interfaces/Configurable.php
+++ b/Core/Interfaces/Configurable.php
@@ -12,3 +12,4 @@ interface Configurable {
 	*/
 	public function configure(Site $site);
 }
+

--- a/Core/Interfaces/Configurable.php
+++ b/Core/Interfaces/Configurable.php
@@ -12,4 +12,3 @@ interface Configurable {
 	*/
 	public function configure(Site $site);
 }
-?>

--- a/Core/Interfaces/Configuration.php
+++ b/Core/Interfaces/Configuration.php
@@ -12,3 +12,4 @@ interface Configuration {
 	*/
 	public getAllProperties();
 }
+

--- a/Core/Interfaces/Configuration.php
+++ b/Core/Interfaces/Configuration.php
@@ -12,4 +12,3 @@ interface Configuration {
 	*/
 	public getAllProperties();
 }
-?>

--- a/Core/Interfaces/Controller.php
+++ b/Core/Interfaces/Controller.php
@@ -13,4 +13,3 @@ interface Controller {
 	*/
 	public function evaluate();
 }
-?>

--- a/Core/Interfaces/Controller.php
+++ b/Core/Interfaces/Controller.php
@@ -13,3 +13,4 @@ interface Controller {
 	*/
 	public function evaluate();
 }
+

--- a/Core/Interfaces/DataRepository.php
+++ b/Core/Interfaces/DataRepository.php
@@ -53,4 +53,3 @@ interface DataRepository {
 	*/
 	public function update($id,$data);
 }
-?>

--- a/Core/Interfaces/DataRepository.php
+++ b/Core/Interfaces/DataRepository.php
@@ -53,3 +53,4 @@ interface DataRepository {
 	*/
 	public function update($id,$data);
 }
+

--- a/Core/Interfaces/Logger.php
+++ b/Core/Interfaces/Logger.php
@@ -35,4 +35,3 @@ interface Logger {
 	*/
 	public function error($message);
 }
-?>

--- a/Core/Interfaces/Logger.php
+++ b/Core/Interfaces/Logger.php
@@ -35,3 +35,4 @@ interface Logger {
 	*/
 	public function error($message);
 }
+

--- a/Core/Interfaces/Site.php
+++ b/Core/Interfaces/Site.php
@@ -88,3 +88,4 @@ interface Site {
 	*/
 	public function getSystemMessages();
 }
+

--- a/Core/Interfaces/Site.php
+++ b/Core/Interfaces/Site.php
@@ -88,4 +88,3 @@ interface Site {
 	*/
 	public function getSystemMessages();
 }
-?>

--- a/Core/Interfaces/SitePage.php
+++ b/Core/Interfaces/SitePage.php
@@ -120,4 +120,3 @@ interface SitePage {
 	*/
 	public function isPublicPage();
 }
-?>

--- a/Core/Interfaces/SitePage.php
+++ b/Core/Interfaces/SitePage.php
@@ -120,3 +120,4 @@ interface SitePage {
 	*/
 	public function isPublicPage();
 }
+

--- a/Core/Interfaces/SystemMessage.php
+++ b/Core/Interfaces/SystemMessage.php
@@ -31,3 +31,4 @@ interface SystemMessage {
 	*/
 	public function getMessage();
 }
+

--- a/Core/Interfaces/SystemMessage.php
+++ b/Core/Interfaces/SystemMessage.php
@@ -31,4 +31,3 @@ interface SystemMessage {
 	*/
 	public function getMessage();
 }
-?>

--- a/Core/Interfaces/ViewRenderer.php
+++ b/Core/Interfaces/ViewRenderer.php
@@ -50,4 +50,3 @@ interface ViewRenderer {
 	*/
 	public function getViewVariable($name);
 }
-?>

--- a/Core/Interfaces/ViewRenderer.php
+++ b/Core/Interfaces/ViewRenderer.php
@@ -50,3 +50,4 @@ interface ViewRenderer {
 	*/
 	public function getViewVariable($name);
 }
+

--- a/Core/Lib/functions.php
+++ b/Core/Lib/functions.php
@@ -34,4 +34,3 @@ function loadFile($class,$nameSpace,$baseDirectory) {
 function nameSpaceToPath($nameSpace) {
     return str_replace('\\', '/', $nameSpace);
 }
-?>

--- a/Core/Lib/functions.php
+++ b/Core/Lib/functions.php
@@ -34,3 +34,4 @@ function loadFile($class,$nameSpace,$baseDirectory) {
 function nameSpaceToPath($nameSpace) {
     return str_replace('\\', '/', $nameSpace);
 }
+


### PR DESCRIPTION
The more recent practices are to never use closing PHP tags for pure PHP files.

This, in practice, is safer and helps prevent sending HTTP headers prematurely.
This also helps prevent random new lines, which under certain conditions, do cause problems.

This is also the recommended practice according to PHP documentation.

see: https://secure.php.net/manual/en/language.basic-syntax.phptags.php