### PR TITLE
Php7 fixes

### DIFF
--- a/Core/Classes/CoreSite.php
+++ b/Core/Classes/CoreSite.php
@@ -25,7 +25,7 @@ class CoreSite extends AbstractSite {
 		$this->setPages($siteConfig['sitePages']);
 		$this->generateSanitizedInputData();
 		$this->setUser();
-		$this->setDynamicRepositoryKey($siteConfig['DYNAMIC_REPOSITORY_KEY']);
+		$this->setDynamicRepositoryKey(isset($siteConfig['DYNAMIC_REPOSITORY_KEY']) ? $siteConfig['DYNAMIC_REPOSITORY_KEY'] : null);
 	}
 
 	/**
@@ -115,7 +115,7 @@ class CoreSite extends AbstractSite {
 		//first check if we've already instantiated this DataRepository
 		$repository = $this->getCachedDataRepository($repositoryName);
 		if (!$repository) {
-			if (is_array($this->getSiteConfig()[$this->getDynamicRepositoryKey()]) && array_key_exists($repositoryName,$this->getSiteConfig()[$this->getDynamicRepositoryKey()])) {
+			if (isset($this->getSiteConfig()[$this->getDynamicRepositoryKey()]) && is_array($this->getSiteConfig()[$this->getDynamicRepositoryKey()]) && array_key_exists($repositoryName, $this->getSiteConfig()[$this->getDynamicRepositoryKey()])) {
 				$repository = new Data\DynamicDatabaseRepository($this->getSiteConfig()[$this->getDynamicRepositoryKey()][$repositoryName]);
 				$this->addCachedDataRepository($repositoryName,$repository);
 			} else {
@@ -216,4 +216,3 @@ class CoreSite extends AbstractSite {
 		$this->dynamicRepositoryKey = $dynamicRepositoryKey;
 	}
 }
-

--- a/Core/Classes/Data/DBObject.php
+++ b/Core/Classes/Data/DBObject.php
@@ -177,6 +177,7 @@ class DBObject extends CoreClasses\CoreObject {
 	*/
 	protected function buildIn($ar,&$bindparams,$varprefix = 'v') {
 		$x=1;
+		$sql = '';
 		foreach ($ar as $value) {
 			$sql .= ":{$varprefix}{$x},";
 			$bindparams[":{$varprefix}{$x}"] = $value;

--- a/Core/Classes/Data/UserDB.php
+++ b/Core/Classes/Data/UserDB.php
@@ -53,7 +53,7 @@ class UserDB extends DBObject implements Interfaces\User {
 		if ($sessionUserId) {
 			$_SESSION[$this->getSessionName()]['sessionData']['userId'] = $sessionUserId;
 		}
-		$this->sessionUserId = $_SESSION[$this->getSessionName()]['sessionData']['userId'];
+		$this->sessionUserId = isset($_SESSION[$this->getSessionName()]['sessionData']['userId']) ? $_SESSION[$this->getSessionName()]['sessionData']['userId'] : null;
 	}
 
 	/**
@@ -152,4 +152,3 @@ class UserDB extends DBObject implements Interfaces\User {
 		return false;
 	}
 }
-

--- a/Core/Classes/Loaders/CoreLoader.php
+++ b/Core/Classes/Loaders/CoreLoader.php
@@ -165,7 +165,8 @@ class CoreLoader implements CoreInterfaces\Loader {
 		if (!empty($config['controllerConfig']['name'])) {
 			$className = $this->getSite()->getControllerClass($config['controllerConfig']['name']);
 			if (class_exists($className)) {
-				$controller = new $className($this->getSite(),$config['controllerConfig']);
+				$site = $this->getSite();
+				$controller = new $className($site, $config['controllerConfig']);
 				$controller->evaluate();
 			}
 		}

--- a/Core/Interfaces/Configuration.php
+++ b/Core/Interfaces/Configuration.php
@@ -10,6 +10,5 @@ interface Configuration {
 	/**
 	*	Provides an associative array of all the properties defined by the Configuration implementation instance
 	*/
-	public getAllProperties();
+	public function getAllProperties();
 }
-


### PR DESCRIPTION
**Fixes:**
- Only variables should be passed by reference in CoreLoader.
- Undefined indexes in session and siteConfig.
- Configuration interfacte method is missing 'function' syntax.