### PR TITLE
Add SAML based User auth option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": ">=7.4",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "onelogin/php-saml": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -76,30 +76,30 @@ class UserSAML extends UserDB {
         }
     }
 
-	public function processLogIn() {
-		$auth = new Auth($this->settings);
+    public function processLogIn() {
+        $auth = new Auth($this->settings);
 
-		if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
-			$requestId = $_SESSION['AuthNRequestID'];
-		} else {
-			$requestId = null;
-		}
+        if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
+            $requestId = $_SESSION['AuthNRequestID'];
+        } else {
+            $requestId = null;
+        }
 
-		$auth->processResponse($requestId);
-		unset($_SESSION['AuthNRequestID']);
+        $auth->processResponse($requestId);
+        unset($_SESSION['AuthNRequestID']);
 
-		$errors = $auth->getErrors();
+        $errors = $auth->getErrors();
 
-		if (!empty($errors)) {
-			throw new \RuntimeException("SAML error: ".implode(', ',$errors));
-		}
+        if (!empty($errors)) {
+            throw new \RuntimeException("SAML error: ".implode(', ',$errors));
+        }
 
-		if (!$auth->isAuthenticated()) {
-			throw new \RuntimeException("SAML error: Not authenticated");
-		}
+        if (!$auth->isAuthenticated()) {
+            throw new \RuntimeException("SAML error: Not authenticated");
+        }
 
-		$samlUserNameParts = explode('@',$auth->getNameId());
-		$samlUserName = $samlUserNameParts[0];
+        $samlUserNameParts = explode('@',$auth->getNameId());
+        $samlUserName = $samlUserNameParts[0];
 
         $tusers = $this->usersRepo;
         //find an existing, active user or create a new one
@@ -118,19 +118,19 @@ class UserSAML extends UserDB {
             $this->buildProfile();
             return true;
         }
-		return false;
-	}
+        return false;
+    }
 
-	public function initiatelogIn() {
-		$auth = new Auth($this->settings);
-		$auth->login();
-	}
+    public function initiatelogIn() {
+        $auth = new Auth($this->settings);
+        $auth->login();
+    }
 
-	public function logOut() {
-		parent::logOut();
-		$auth = new Auth($this->settings);
-		$auth->logout();
-	}
+    public function logOut() {
+        parent::logOut();
+        $auth = new Auth($this->settings);
+        $auth->logout();
+    }
 
     public function logIn($username,$password) {
         return false;

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -1,0 +1,135 @@
+<?php
+namespace Pipit\Classes\Data;
+
+use Pipit\Classes\Exceptions\ConfigurationException;
+use OneLogin\Saml2\Auth;
+
+class UserSAML extends UserDB {
+    use \Pipit\Traits\FileConfiguration;
+
+    /** @var array<string,array<string,string>> $casPaths A string array representing the CAS configuration */
+    private $samlPaths;
+    /** @var \Pipit\Interfaces\DataRepository $usersRepo A DataRepository representing the app's Users (assumes existence of 'username' and 'iscas' fields) */
+    private $usersRepo;
+
+    private $settings;
+
+    private const CONFIG_FILE = "user.saml";
+
+
+    /**
+    *	Instantiates a new UserCAS by negotiating the login process with a configured CAS Server
+    *	@param mixed[] $inputData The input data from the request
+    *	@param \Pipit\Interfaces\DataRepository $usersRepo A DataRepository representing the app's Users (assumes existence of 'username' and 'iscas' fields)
+    */
+    public function __construct($inputData, $usersRepo) {
+
+        $this->loadSettings();
+
+        parent::__construct();
+
+        $appConfig = $this->getAppConfiguration();
+        $redirectUrl = is_string($this->settings['redirect']) ? $this->settings['redirect']:$appConfig['PATH_HTTP'];
+
+        if (!empty($inputData['SAMLResponse'])) {
+            $this->usersRepo = $usersRepo;
+
+            if (is_string($inputData['SAMLResponse']) && $this->processLogIn($inputData['SAMLResponse'])) {
+                header("Location:".$redirectUrl);
+            }
+        } elseif (!$this->isLoggedIn() && !isset($inputData['action'])) {
+            $this->initiateLogIn();
+        }
+    }
+
+    protected function checkSettings() {
+        return (is_array($this->settings)
+                && is_string($this->settings['idp']['entityId'])
+                && is_string($this->settings['idp']['singleLogoutService'])
+                && is_string($this->settings['idp']['responseUrl'])
+                && is_string($this->settings['idp']['x509cert']));
+    }
+
+    protected function loadSettings() {
+        $configurationFileName = self::CONFIG_FILE;
+        $config = null;
+        if ($this->configurationFileExists($configurationFileName)) {
+            $config = $this->getConfigurationFromFileName($configurationFileName);
+        } else {
+            throw new ConfigurationException("SAML config file does not exist");
+        }
+
+        $defaultSettingsFile = __DIR__."/../../../../../vendor/onelogin/php-saml/settings_example.php";
+        if (is_file($defaultSettingsFile)) {
+            require($defaultSettingsFile);
+        } else {
+            throw new ConfigurationException("Default Settings file is missing. Have you run composer install?");
+        }
+        $this->settings = array_replace($settings, $config);
+
+        if (!$this->checkSettings()) {
+            throw new ConfigurationException("Invalid SAML settings. Please check ".$configurationFileName);
+        }
+    }
+
+	public function processLogIn() {
+		$auth = new Auth($this->settings);
+
+		if (isset($_SESSION) && isset($_SESSION['AuthNRequestID'])) {
+			$requestId = $_SESSION['AuthNRequestID'];
+		} else {
+			$requestId = null;
+		}
+
+		$auth->processResponse($requestId);
+		unset($_SESSION['AuthNRequestID']);
+
+		$errors = $auth->getErrors();
+
+		if (!empty($errors)) {
+			throw new \RuntimeException("SAML error: ".implode(', ',$errors));
+		}
+
+		if (!$auth->isAuthenticated()) {
+			throw new \RuntimeException("SAML error: Not authenticated");
+		}
+
+		$samlUserNameParts = explode('@',$auth->getNameId());
+		$samlUserName = $samlUserNameParts[0];
+
+        $tusers = $this->usersRepo;
+        //find an existing, active user or create a new one
+        $user = $tusers->searchAdvanced(array("username"=>$samlUserName));
+        if ($user && is_array($user)) {
+            if ($user[0]['inactive'] == 0) {
+                $userId = $user[0]['id'];
+            }
+        } elseif (!empty($samlUserName)) {
+            $userId = $tusers->add(array("username"=>$samlUserName,"iscas"=>1));
+        }
+        if (!empty($userId)) {
+            session_regenerate_id(true);
+            session_start();
+            $this->setSessionUserId($userId);
+            $this->buildProfile();
+            return true;
+        }
+		return false;
+	}
+
+	public function initiatelogIn() {
+		$auth = new Auth($this->settings);
+		$auth->login();
+	}
+
+	public function logOut() {
+		parent::logOut();
+		$auth = new Auth($this->settings);
+		$auth->logout();
+	}
+
+    public function logIn($username,$password) {
+        return false;
+    }
+}
+?>

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -121,7 +121,7 @@ class UserSAML extends UserDB {
             if ($user[0]['inactive'] == 0) {
                 $userId = $user[0]['id'];
             }
-        } elseif (!empty($samlNetId)) {
+        } elseif (!empty($userName)) {
             $userId = $tusers->add(array("username"=>$userName,"issaml"=>1));
         }
         if (!empty($userId)) {

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -45,7 +45,8 @@ class UserSAML extends UserDB {
     protected function checkSettings() {
         return (is_array($this->settings)
                 && is_string($this->settings['idp']['entityId'])
-                && is_string($this->settings['idp']['singleLogoutService'])
+                && is_string($this->settings['idp']['singleSignOnServiceUrl'])
+                && is_string($this->settings['idp']['singleLogoutServiceUrl'])
                 && is_string($this->settings['idp']['responseUrl'])
                 && is_string($this->settings['idp']['x509cert']));
     }

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -137,7 +137,6 @@ class UserSAML extends UserDB {
     /**
      * Triggers the SAML login request
      */
-
     public function initiatelogIn() {
         $auth = new Auth($this->settings);
         $auth->login();

--- a/src/Pipit/Classes/Data/UserSAML.php
+++ b/src/Pipit/Classes/Data/UserSAML.php
@@ -44,11 +44,14 @@ class UserSAML extends UserDB {
 
     protected function checkSettings() {
         return (is_array($this->settings)
-                && is_string($this->settings['idp']['entityId'])
-                && is_string($this->settings['idp']['singleSignOnServiceUrl'])
-                && is_string($this->settings['idp']['singleLogoutServiceUrl'])
-                && is_string($this->settings['idp']['responseUrl'])
-                && is_string($this->settings['idp']['x509cert']));
+                && !empty($this->settings['sp']['entityId'])
+                && !empty($this->settings['sp']['assertionConsumerService']['url'])
+                && !empty($this->settings['sp']['singleLogoutService']['url'])
+                && !empty($this->settings['idp']['entityId'])
+                && !empty($this->settings['idp']['singleSignOnService']['url'])
+                && !empty($this->settings['idp']['singleLogoutService']['url'])
+                && !empty($this->settings['idp']['singleLogoutService']['responseUrl'])
+                && !empty($this->settings['idp']['x509cert']));
     }
 
     protected function loadSettings() {
@@ -60,7 +63,7 @@ class UserSAML extends UserDB {
             throw new ConfigurationException("SAML config file does not exist");
         }
 
-        $defaultSettingsFile = __DIR__."/../../../../../vendor/onelogin/php-saml/settings_example.php";
+        $defaultSettingsFile = __DIR__."/../../../../../../onelogin/php-saml/settings_example.php";
         if (is_file($defaultSettingsFile)) {
             require($defaultSettingsFile);
         } else {

--- a/src/Pipit/Classes/Site/CoreSite.php
+++ b/src/Pipit/Classes/Site/CoreSite.php
@@ -50,6 +50,24 @@ class CoreSite extends AbstractSite {
                     throw new ConfigurationException("Configured User class not found: {$className}");
                 }
             }
+            if ($userClass && is_bool($config['USESAML']) && $config['USESAML']) {
+                if ($config['SAML_USER_REPO']) {
+                    $userRepo = $this->getDataRepository($config['SAML_USER_REPO']);
+                    if ($userRepo instanceof \Pipit\Interfaces\DataRepository) {
+                        if ($userClass instanceof \Pipit\Classes\Data\UserSAML) {
+                            $userClass = new Data\UserSAML($this->getSanitizedInputData(),$userRepo);
+                            unset($userRepo);
+                        } else {
+                            $userClass = null;
+                            throw new ConfigurationException("Configured UserSAML classes must extend Pipit\Classes\Data\UserSAML");
+                        }
+                    } else {
+                        throw new ConfigurationException("UserSAML requires a Pipit\Interfaces\DataRepository");
+                    }
+                } else {
+                    throw new ConfigurationException("UserSAML requires SAML_USER_REPO to be defined with a Pipit\Interfaces\DataRepository");
+                }
+            }
             if ($userClass && is_bool($config['USECAS']) && $config['USECAS']) {
                 if ($config['CAS_USER_REPO']) {
                     $userRepo = $this->getDataRepository($config['CAS_USER_REPO']);

--- a/src/Pipit/Classes/Site/CoreSite.php
+++ b/src/Pipit/Classes/Site/CoreSite.php
@@ -50,7 +50,7 @@ class CoreSite extends AbstractSite {
                     throw new ConfigurationException("Configured User class not found: {$className}");
                 }
             }
-            if ($userClass && is_bool($config['USESAML']) && $config['USESAML']) {
+            if (!$userClass && is_bool($config['USESAML']) && $config['USESAML']) {
                 if ($config['SAML_USER_REPO']) {
                     $userRepo = $this->getDataRepository($config['SAML_USER_REPO']);
                     if ($userRepo instanceof \Pipit\Interfaces\DataRepository) {
@@ -68,7 +68,7 @@ class CoreSite extends AbstractSite {
                     throw new ConfigurationException("UserSAML requires SAML_USER_REPO to be defined with a Pipit\Interfaces\DataRepository");
                 }
             }
-            if ($userClass && is_bool($config['USECAS']) && $config['USECAS']) {
+            if (!$userClass && is_bool($config['USECAS']) && $config['USECAS']) {
                 if ($config['CAS_USER_REPO']) {
                     $userRepo = $this->getDataRepository($config['CAS_USER_REPO']);
                     if ($userRepo instanceof \Pipit\Interfaces\DataRepository) {

--- a/tests/CoreSiteTest.php
+++ b/tests/CoreSiteTest.php
@@ -60,6 +60,33 @@ class CoreSiteTest extends \Codeception\Test\Unit
         $this->assertEquals('Pipit\Classes\Data\UserCAS',get_class($coreSite->getGlobalUser()));
     }
 
+    public function testConfiguredSamlUser()
+    {
+        $this->config['SAML_USER_REPO'] = 'TestDataRepository';
+        $coreSite = $this->getCoreSiteInstance('TestUserSAML');
+        $this->assertEquals('TestFiles\Classes\Data\TestUserSAML',get_class($coreSite->getGlobalUser()));
+    }
+
+    public function testConfiguredSamlUserWithNoRepository()
+    {
+        $this->config['USESAML'] = true;
+        $this->config['SAML_USER_REPO'] = null;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("UserSAML requires SAML_USER_REPO to be defined with a Pipit\Interfaces\DataRepository");
+
+        $coreSite = $this->getCoreSiteInstance('TestUserSAML');
+    }
+
+    public function testDefaultSamlUser()
+    {
+        $this->config['USE_SAML'] = true;
+        //We will fail to connect to a non-existent database, but we're only testing that the right class is set for the globalUser
+        $this->expectException(\PDOException::class);
+        $coreSite = $this->getDefaultCoreSiteInstance();
+        $this->assertEquals('Pipit\Classes\Data\UserSAML',get_class($coreSite->getGlobalUser()));
+    }
+
     public function testDefaultUser()
     {
         //We will fail to connect to a non-existent database, but we're only testing that the right class is set for the globalUser

--- a/tests/TestFiles/Classes/Data/TestUserSAML.php
+++ b/tests/TestFiles/Classes/Data/TestUserSAML.php
@@ -1,0 +1,30 @@
+<?php
+namespace TestFiles\Classes\Data;
+use Pipit\Interfaces as Interfaces;
+
+class TestUserSAML implements Interfaces\User {
+	public function logOut() {
+		return true;
+	}
+
+	public function logIn($username,$password) {
+		return true;
+	}
+
+	public function isLoggedIn() {
+		return true;
+	}
+
+	public function getProfileValue($field) {
+		return null;
+	}
+
+	public function getProfile() {
+		return [];
+	}
+
+	public function isAdmin() {
+		return false;
+	}
+}
+?>

--- a/tests/TestFiles/Config/user.saml.ini
+++ b/tests/TestFiles/Config/user.saml.ini
@@ -1,0 +1,12 @@
+base = http://localhost
+path_http = PATH_HTTP
+
+[idp]
+entityId = "{{base}}/saml/login?service={{path_http}}"
+singleLogoutService = "{{base}}/saml/logout?service={{path_http}}user.php?action=logout"
+responseUrl = {{path_http}}
+x509cert = ""
+
+;The default post-login redirect behavior is to redirect to the application's home page
+;This can be overridden by defining a custom redirect path
+;redirect = {{path_http}}

--- a/tests/TestFiles/Config/user.saml.ini
+++ b/tests/TestFiles/Config/user.saml.ini
@@ -1,10 +1,16 @@
-base = http://localhost
 path_http = PATH_HTTP
 
 [idp]
-entityId = "{{base}}/saml/login?service={{path_http}}"
-singleLogoutService = "{{base}}/saml/logout?service={{path_http}}user.php?action=logout"
-responseUrl = {{path_http}}
+;Identifier of the IdP entity  (must be a URI)
+entityId = ""
+;URL Target of the IdP where the SP will send the Authentication Request Message
+singleSignOnServiceUrl = ""
+;URL Location of the IdP where the SP will send the SLO Request
+singleLogoutServiceUrl = ""
+;URL location of the IdP where the SP SLO Response will be sent (ResponseLocation)
+;if not set, singleSignOnServiceUrl will be used
+;responseUrl = {{path_http}}
+;Public x509 certificate of the IdP
 x509cert = ""
 
 ;The default post-login redirect behavior is to redirect to the application's home page

--- a/tests/TestFiles/Config/user.saml.ini
+++ b/tests/TestFiles/Config/user.saml.ini
@@ -1,3 +1,7 @@
+[claims]
+;Optionally override the default 'netid' claim mapping
+;username =
+
 [sp]
 ;Identifier of the SP entity  (must be a URI)
 entityId = PATH_HTTP

--- a/tests/TestFiles/Config/user.saml.ini
+++ b/tests/TestFiles/Config/user.saml.ini
@@ -1,18 +1,18 @@
-path_http = PATH_HTTP
+[sp]
+;Identifier of the SP entity  (must be a URI)
+entityId = PATH_HTTP
+;Where the <AuthnResponse> message MUST be returned
+assertionConsumerService[url] = PATH_HTTP
+;Where the <Response> from the IdP will be returned
+singleLogoutService[url] = PATH_HTTP
 
 [idp]
-;Identifier of the IdP entity  (must be a URI)
-entityId = ""
-;URL Target of the IdP where the SP will send the Authentication Request Message
-singleSignOnServiceUrl = ""
-;URL Location of the IdP where the SP will send the SLO Request
-singleLogoutServiceUrl = ""
-;URL location of the IdP where the SP SLO Response will be sent (ResponseLocation)
-;if not set, singleSignOnServiceUrl will be used
-;responseUrl = {{path_http}}
-;Public x509 certificate of the IdP
-x509cert = ""
+entityId =
+singleSignOnService[url] =
+singleLogoutService[url] =
+singleLogoutService[responseUrl] = PATH_HTTP
+x509cert =
 
 ;The default post-login redirect behavior is to redirect to the application's home page
 ;This can be overridden by defining a custom redirect path
-;redirect = {{path_http}}
+;redirect = PATH_HTTP

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -31,6 +31,8 @@ define('USECAS', false);
 //Optionally define a custom implementation of \Pipit\Interfaces\User to be used for the GlobalUser
 //define('USER_CLASS',NAMESPACE_CORE.'\\Classes\Data\\UserCAS');
 
+define('USESAML', false);
+
 define('SECURITY_PUBLIC',-1);
 define('SECURITY_USER',0);
 define('SECURITY_ADMIN',1);


### PR DESCRIPTION
Provides client with a generalized SAML based User auth strategy via the OneLogin PHP SAML library.

Currently intended for use with Microsoft EntraID but expected to be compatible with any valid SAML implementation.