### PR TITLE
HTMLViewRendered view path fallback default is invalid.

### DIFF
--- a/src/Pipit/Classes/ViewRenderers/HTMLViewRenderer.php
+++ b/src/Pipit/Classes/ViewRenderers/HTMLViewRenderer.php
@@ -43,11 +43,21 @@ class HTMLViewRenderer extends CoreObject implements ViewRenderer {
         if (!empty($config['ACTIVE_THEME'])) {
             $themeFolder = $config['ACTIVE_THEME'];
             $viewPath = $config['PATH_VIEWS'].$themeFolder;
-             if (is_dir($viewPath)) {
-                $this->setViewPath($viewPath.'/');
+            $fallback = 'html/';
+
+            if (is_dir($viewPath)) {
+                $this->setViewPath("{$viewPath}/");
             } else {
-                $this->getLogger()->warn("Could not find theme folder: ".$themeFolder.", falling back to default");
-                $this->setViewPath('html');
+                $viewPath = "{$config['PATH_VIEWS']}{$fallback}";
+                if (is_dir($viewPath)) {
+                  $this->getLogger()->warn("Could not find theme folder: {$themeFolder}, falling back to theme path default");
+                  $this->setViewPath($viewPath);
+                } else if (is_dir($fallback)) {
+                  $this->getLogger()->warn("Could not find theme folder: {$themeFolder} or fall back theme path {$fallback}, falling back to default {$fallback}");
+                  $this->setViewPath($fallback);
+                } else {
+                  $this->getLogger()->error("Could not find theme folder: {$themeFolder}, fall back theme path {$fallback}, or fall back default {$fallback}");
+                }
             }
         }
     }


### PR DESCRIPTION
There are two problems with the fallback default path.
  1. The trailing slash is required but is missing (see `renderView()`, for code like this `"{$this->getViewPath()}layouts/header.lo.php"`).
  2. The view path is not pointing to the path views config directory.

Fix the first case by always appending a trailing slash.

Fix the second case as follows:
  1. If requested view path is found, then use it; otherwise...
  2. If the fallback theme directory (`html`) exists within the theme folder, then use it; otherwise...
  3. If the theme folder folder fall back is not found and the `html` directory without a theme path exists, then use it; otherwise...
  4. Log an error describing the situation.

This error prevents random confusing problems about paths not existing in different areas of the code. This error prints where the error actually is and describes the missing paths.