### PR TITLE
Prevent infinite loop if unable to find controller at root path.

### DIFF
--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -214,7 +214,7 @@ class CoreLoader extends CoreObject implements Loader {
             $this->getLogger()->warn($message);
             $site = $this->getSite();
             $page = isset($site) ? $site->getCurrentPage() : null;
-            $path = isset($page) ? $site->getCurrentPage()->getPath() : '';
+            $path = isset($page) ? $page->getPath() : '';
             if (!empty($path) && $this->isString($config, 'PATH_HTTP')) {
                 $this->getSite()->setRedirectUrl($config['PATH_HTTP']);
             } else {

--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -196,6 +196,7 @@ class CoreLoader extends CoreObject implements Loader {
         //try to load the controller
         $config = $this->getConfig();
         $controller = null;
+        $className = null;
         if ($this->isArray($config, 'controllerConfig') && $this->isString($config['controllerConfig'], 'name')) {
             $className = $this->getSite()->getControllerClass($config['controllerConfig']['name']);
             if (class_exists($className)) {
@@ -209,11 +210,15 @@ class CoreLoader extends CoreObject implements Loader {
             }
         }
         if (!$controller) {
-            $this->getLogger()->warn("Did not find Controller Class");
-            if ($this->isString($config, 'PATH_HTTP')) {
+            $message = "Did not find Controller Class {$className}.";
+            $this->getLogger()->warn($message);
+            $site = $this->getSite();
+            $page = isset($site) ? $site->getCurrentPage(): null;
+            $path = isset($page) ? $site->getCurrentPage()->getPath() : '';
+            if (!empty($path) && $this->isString($config, 'PATH_HTTP')) {
                 $this->getSite()->setRedirectUrl($config['PATH_HTTP']);
             } else {
-                exit;
+                throw new \RuntimeException($message);
             }
         }
     }

--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -210,7 +210,7 @@ class CoreLoader extends CoreObject implements Loader {
             }
         }
         if (!$controller) {
-            $message = $className == NULL
+            $message = $className == null
                 ? "Cannot load Controller Class; could not load the class name."
                 : "Did not find Controller Class {$className}.";
             $this->getLogger()->warn($message);

--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -213,7 +213,7 @@ class CoreLoader extends CoreObject implements Loader {
             $message = "Did not find Controller Class {$className}.";
             $this->getLogger()->warn($message);
             $site = $this->getSite();
-            $page = isset($site) ? $site->getCurrentPage(): null;
+            $page = isset($site) ? $site->getCurrentPage() : null;
             $path = isset($page) ? $site->getCurrentPage()->getPath() : '';
             if (!empty($path) && $this->isString($config, 'PATH_HTTP')) {
                 $this->getSite()->setRedirectUrl($config['PATH_HTTP']);

--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -218,7 +218,7 @@ class CoreLoader extends CoreObject implements Loader {
             if (!empty($path) && $this->isString($config, 'PATH_HTTP')) {
                 $this->getSite()->setRedirectUrl($config['PATH_HTTP']);
             } else {
-                throw new \RuntimeException($message);
+                exit;
             }
         }
     }

--- a/src/Pipit/Classes/Loaders/CoreLoader.php
+++ b/src/Pipit/Classes/Loaders/CoreLoader.php
@@ -210,7 +210,9 @@ class CoreLoader extends CoreObject implements Loader {
             }
         }
         if (!$controller) {
-            $message = "Did not find Controller Class {$className}.";
+            $message = $className == NULL
+                ? "Cannot load Controller Class; could not load the class name."
+                : "Did not find Controller Class {$className}.";
             $this->getLogger()->warn($message);
             $site = $this->getSite();
             $page = isset($site) ? $site->getCurrentPage() : null;


### PR DESCRIPTION
This redirects if the controller is not found even if the path is the redirect path. Prevent this by checking if path is empty and only then redirect.

Rather than exit on failure, throw a runtime exception with the appropriate message when this happens at the root path.